### PR TITLE
Timestamps written in SQLite-compatible format. Fixes #13.

### DIFF
--- a/src/Serilog.Sinks.SQLite/LoggerConfigurationSQLiteExtensions.cs
+++ b/src/Serilog.Sinks.SQLite/LoggerConfigurationSQLiteExtensions.cs
@@ -45,7 +45,8 @@ namespace Serilog
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
             bool storeTimestampInUtc = false,
-            TimeSpan? retentionPeriod = null)
+            TimeSpan? retentionPeriod = null,
+            TimeSpan? retentionCheckInterval = null)
         {
             if (loggerConfiguration == null)
             {
@@ -82,7 +83,8 @@ namespace Serilog
                         tableName,
                         formatProvider,
                         storeTimestampInUtc,
-                        retentionPeriod),
+                        retentionPeriod,
+                        retentionCheckInterval),
                     restrictedToMinimumLevel);
             }
             catch (Exception ex)

--- a/src/Serilog.Sinks.SQLite/Sinks/SQLite/SQLiteSink.cs
+++ b/src/Serilog.Sinks.SQLite/Sinks/SQLite/SQLiteSink.cs
@@ -131,8 +131,8 @@ namespace Serilog.Sinks.SQLite
                             foreach (var logEvent in logEventsBatch)
                             {
                                 sqlCommand.Parameters["@timeStamp"].Value = _storeTimestampInUtc
-                                    ? logEvent.Timestamp.ToUniversalTime()
-                                    : logEvent.Timestamp;
+                                    ? logEvent.Timestamp.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss")
+                                    : logEvent.Timestamp.ToString("yyyy-MM-ddTHH:mm:ss");
                                 sqlCommand.Parameters["@level"].Value = logEvent.Level.ToString();
                                 sqlCommand.Parameters["@exception"].Value = logEvent.Exception?.ToString() ?? string.Empty;
                                 sqlCommand.Parameters["@renderedMessage"].Value = logEvent.MessageTemplate.ToString();
@@ -186,7 +186,7 @@ namespace Serilog.Sinks.SQLite
             cmd.CommandText = $"DELETE FROM {_tableName} WHERE Timestamp < @epoch";
             cmd.Parameters.Add(new SQLiteParameter("@epoch", DbType.DateTime2)
             {
-                Value = _storeTimestampInUtc ? epoch.ToUniversalTime() : epoch
+                Value = (_storeTimestampInUtc ? epoch.ToUniversalTime() : epoch).ToString("yyyy-MM-ddTHH:mm:ss")
             });
             return cmd;
         }


### PR DESCRIPTION
As per #13, SQLite only accepts certain DateTime formats. This PR changes the format to match.