### PR TITLE
Closes #28 maxDatabaseSize malfunction due to Delete query in Truncate function

### DIFF
--- a/src/Serilog.Sinks.SQLite/Sinks/SQLite/SQLiteSink.cs
+++ b/src/Serilog.Sinks.SQLite/Sinks/SQLite/SQLiteSink.cs
@@ -180,6 +180,15 @@ namespace Serilog.Sinks.SQLite
             var cmd = sqlConnection.CreateCommand();
             cmd.CommandText = $"DELETE FROM {_tableName}";
             cmd.ExecuteNonQuery();
+
+            VacuumDatabase(sqlConnection);
+        }
+
+        private void VacuumDatabase(SQLiteConnection sqlConnection)
+        {
+            var cmd = sqlConnection.CreateCommand();
+            cmd.CommandText = $"vacuum";
+            cmd.ExecuteNonQuery();
         }
 
         private SQLiteCommand CreateSqlDeleteCommand(SQLiteConnection sqlConnection, DateTimeOffset epoch)


### PR DESCRIPTION
Added a VacuumDatabase function that will be called after TruncateDatabase function so that db size is reset to 0