### PR TITLE
Change to use universal time in hours

### DIFF
--- a/src/Serilog.Sinks.SQLite/Sinks/SQLite/SQLiteSink.cs
+++ b/src/Serilog.Sinks.SQLite/Sinks/SQLite/SQLiteSink.cs
@@ -236,7 +236,7 @@ namespace Serilog.Sinks.SQLite
                         var dbExtension = Path.GetExtension(_databasePath);
 
                         var newFilePath = Path.Combine(Path.GetDirectoryName(_databasePath) ?? "Logs",
-                            $"{Path.GetFileNameWithoutExtension(_databasePath)}-{DateTime.Now:yyyyMMdd_hhmmss.ff}{dbExtension}");
+                            $"{Path.GetFileNameWithoutExtension(_databasePath)}-{DateTime.Now:yyyyMMdd_HHmmss.ff}{dbExtension}");
                          
                         File.Copy(_databasePath, newFilePath, true);
 


### PR DESCRIPTION
Instead of using hh(12 hours / am /pm), use HH (24 hours) to represent hour in newly generated files and those would be ordered in the file system.