### PR TITLE
Suppress exceptions and backup file

### DIFF
--- a/src/Serilog.Sinks.SQLite/LoggerConfigurationSQLiteExtensions.cs
+++ b/src/Serilog.Sinks.SQLite/LoggerConfigurationSQLiteExtensions.cs
@@ -41,6 +41,8 @@ namespace Serilog
         /// <param name="retentionCheckInterval">Time period to execute TTL process. Time span should be in 15 minutes increment</param>
         /// <param name="batchSize">Number of messages to save as batch to database. Default is 10, max 1000</param>
         /// <param name="levelSwitch">
+        /// <param name="neverCrash">Do not crash if database file becomes corrupted. Defaults to false for backwards compatibility.</param>
+        /// <param name="backupCorruptedFileOnInitialization">Backup database file on initialization if it corrupted. neverCrash must be true.</param>
         /// A switch allowing the pass-through minimum level to be changed at runtime.
         /// </param>
         /// <param name="maxDatabaseSize">Maximum database file size can grow in MB. Default 10 MB, maximum 20 GB</param>
@@ -59,7 +61,9 @@ namespace Serilog
             LoggingLevelSwitch levelSwitch = null,
             uint batchSize = 100,
             uint maxDatabaseSize = 10,
-            bool rollOver = true)
+            bool rollOver = true,
+            bool neverCrash = false,
+            bool backupCorruptedFileOnInitialization = true)
         {
             if (loggerConfiguration == null) {
                 SelfLog.WriteLine("Logger configuration is null");
@@ -96,7 +100,8 @@ namespace Serilog
                         retentionCheckInterval,
                         batchSize,
                         maxDatabaseSize,
-                        rollOver),
+                        rollOver,
+                        neverCrash),
                     restrictedToMinimumLevel,
                     levelSwitch);
             }

--- a/src/Serilog.Sinks.SQLite/Serilog.Sinks.SQLite.csproj
+++ b/src/Serilog.Sinks.SQLite/Serilog.Sinks.SQLite.csproj
@@ -15,7 +15,7 @@
         <Version>6.0.0</Version>
         <SignAssembly>True</SignAssembly>
         <AssemblyOriginatorKeyFile>Serilog.snk</AssemblyOriginatorKeyFile>
-        <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net7.0;net8.0</TargetFrameworks>
         <FileVersion>6.0.0.0</FileVersion>
     </PropertyGroup>
     <PropertyGroup>
@@ -50,4 +50,9 @@
         <Version>7.0.5</Version>
       </PackageReference>
     </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+	  <PackageReference Include="Microsoft.Data.Sqlite.Core">
+		<Version>7.0.5</Version>
+	  </PackageReference>
+	</ItemGroup>
 </Project>

--- a/src/Serilog.Sinks.SQLite/Serilog.Sinks.SQLite.csproj
+++ b/src/Serilog.Sinks.SQLite/Serilog.Sinks.SQLite.csproj
@@ -1,5 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
+	<PropertyGroup>
+		<NoWarn>$(NoWarn);NETSDK1206</NoWarn>
+	</PropertyGroup>
+	<PropertyGroup>
         <AssemblyTitle>Serilog.Sinks.SQLite</AssemblyTitle>
         <Authors>Saleem Mirza</Authors>
         <AssemblyName>Serilog.Sinks.SQLite</AssemblyName>

--- a/src/Serilog.Sinks.SQLite/Sinks/SQLite/SQLiteSink.cs
+++ b/src/Serilog.Sinks.SQLite/Sinks/SQLite/SQLiteSink.cs
@@ -147,7 +147,7 @@ namespace Serilog.Sinks.SQLite
             {
                 // If process is killed while writing then db file may become corrupted and won't open.
                 // Often we see a malformed disk image error. Unless we handle this case, application will crash.
-                if (initializing && _backupCorruptedFileOnInitialization)
+                if (initializing && _backupCorruptedFileOnInitialization && _neverCrash)
                 {
                     // We only back up when initializing to in case the exception on open would be caused by something else
                     // like write permissions errors.  Don't want to be creating a backup for every attempted use that goes wrong.


### PR DESCRIPTION
Suppress exceptions and backup file so consuming app will not crash if database file is corrupted.

If app is killed during DB File access file can become corrupt generating a "malformed disk image" exception. If this happens during application startup app can crash.

Added in sink configuration options to 

1) suppress exceptions and not crash.
2) Back up file using rollover naming conventions and .ERR extension.

Only does back up on initialization. If exception is caused by, say, not having write permissions on the file but still having create permissions for the folder, every attempt to access the file would create a new backup of the same corrupted file.