### PR TITLE
Add Pragma generic list to be included in SQLite connection string

### DIFF
--- a/src/Serilog.Sinks.SQLite/LoggerConfigurationSQLiteExtensions.cs
+++ b/src/Serilog.Sinks.SQLite/LoggerConfigurationSQLiteExtensions.cs
@@ -17,6 +17,7 @@ using Serilog.Debugging;
 namespace Serilog
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using Serilog.Configuration;
     using Serilog.Core;
@@ -59,7 +60,8 @@ namespace Serilog
             LoggingLevelSwitch levelSwitch = null,
             uint batchSize = 100,
             uint maxDatabaseSize = 10,
-            bool rollOver = true)
+            bool rollOver = true,
+            List<string> pragmas = null)
         {
             if (loggerConfiguration == null) {
                 SelfLog.WriteLine("Logger configuration is null");
@@ -96,7 +98,8 @@ namespace Serilog
                         retentionCheckInterval,
                         batchSize,
                         maxDatabaseSize,
-                        rollOver),
+                        rollOver,
+                        pragmas),
                     restrictedToMinimumLevel,
                     levelSwitch);
             }


### PR DESCRIPTION
### Adding pragma statements to SQLite is vital for the underlaying database. 

By adding a generic list, the end user could add items manually that they would like to tweak on their instance.

Because this relates to logging, it could be easy for the user to add in the [pragma_auto_vacuum](https://www.sqlite.org/pragma.html#pragma_auto_vacuum) in the list and ensure there is no need to call the vacuum command after bulk deletes.

This PR is adding `List<string>` to the configuration extension that passes it through to the connection string to be appended.

Example: 
```csharp
List<string> PragmaItems = new List<string>
{
    {"auto_vacuum=FULL"}
};
```
and then in the LoggerConfiguration:
```csharp
.WriteTo.SQLite(System.IO.Path.Combine("C:\SomeDirectory", "SomeSQLiteDB.db"),pragmas: PragmaItems)
```
The result would end with the SQLiteConnectionStringBuilder from the current default:
`data source="C:\SomeDirectory\SomeSQLiteDB";journal mode=Memory;synchronous=Normal;cache size=500;page size=4096;max page count=2560`
to:
`data source="C:\SomeDirectory\SomeSQLiteDB";journal mode=Memory;synchronous=Normal;cache size=500;page size=4096;max page count=2560;auto_vacuum=FULL;`